### PR TITLE
Add an optional image tag filter for notifications, make slack channel optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ module "ecr-scan-notify-lambda" {
     SLACK_EMOJI       = var.slack_emoji
     SLACK_WEBHOOK_URL = var.slack_webhook_url
     RISK_LEVELS       = var.risk_levels
+    TAG_TO_NOTIFY     = var.tag_to_notify
 
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,11 @@ variable "risk_levels" {
   default    = "HIGH, CRITICAL"
 }
 
+variable "tag_to_notify" {
+  description = "An optional image tag, for slack reports should be generated: e.g. latest"
+  type        = string
+}
+
 variable "subnet_ids" {
   description = "VPC subnets for Lambda"
   type        = list(string)


### PR DESCRIPTION
An enhancement to the forked repo, so that we can only be notified for vulnerabilities with a certain tag, e.g. latest